### PR TITLE
Fix CI failure

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -29,10 +29,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.config.rust-version }}
-          default: true
+          targets: ${{ matrix.config.rust-target }}
 
       - uses: r-lib/actions/setup-pandoc@v2
 

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -21,6 +21,7 @@ jobs:
           - {os: windows-latest, r: 'release', rust-version: 'stable-msvc'}
           - {os: macOS-latest,   r: 'release', rust-version: 'stable'}
           - {os: ubuntu-latest,  r: 'release', rust-version: 'stable'}
+          - {os: ubuntu-latest,  r: 'devel',   rust-version: 'stable'}
 
     env:
       R_REMOTES_NO_ERRORS_FROM_WARNINGS: true

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - {os: windows-latest, r: 'release', rust-version: 'stable-msvc'}
+          - {os: windows-latest, r: 'release', rust-version: 'stable-msvc', rust-target: 'x86_64-pc-windows-gnu'}
           - {os: macOS-latest,   r: 'release', rust-version: 'stable'}
           - {os: ubuntu-latest,  r: 'release', rust-version: 'stable'}
           - {os: ubuntu-latest,  r: 'devel',   rust-version: 'stable'}

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -25,7 +25,6 @@ jobs:
 
     env:
       R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
-      TOOLCHAIN: ${{ matrix.config.rust-version }}
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -40,7 +40,6 @@ jobs:
         with:
           r-version: ${{ matrix.config.r }}
           use-public-rspm: true
-          rtools-version: ${{ matrix.config.rtools-version }}
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -18,8 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - {os: windows-latest, r: 'release', rust-version: 'stable-msvc', rtools-version: '42'}
-          - {os: windows-latest, r: '4.1',     rust-version: 'stable-msvc'}
+          - {os: windows-latest, r: 'release', rust-version: 'stable-msvc'}
           - {os: macOS-latest,   r: 'release', rust-version: 'stable'}
           - {os: ubuntu-latest,  r: 'release', rust-version: 'stable'}
 
@@ -34,12 +33,6 @@ jobs:
         with:
           toolchain: ${{ matrix.config.rust-version }}
           default: true
-
-      - name: Add Rust targets for R < 4.2 on Windows
-        if: startsWith(runner.os, 'Windows') && matrix.config.r == '4.1'
-        run: |
-          rustup target add x86_64-pc-windows-gnu
-          rustup target add i686-pc-windows-gnu
 
       - uses: r-lib/actions/setup-pandoc@v2
 

--- a/README.md
+++ b/README.md
@@ -10,10 +10,9 @@ This is a template package to demonstrate how to call Rust from R using the [ext
 
 Before you can install this package, you need to install a working Rust toolchain. We recommend using [rustup.](https://rustup.rs/)
 
-On Windows, you'll also have to add the `i686-pc-windows-gnu` and `x86_64-pc-windows-gnu` targets:
+On Windows, you'll also have to add the `x86_64-pc-windows-gnu` target:
 ```
 rustup target add x86_64-pc-windows-gnu
-rustup target add i686-pc-windows-gnu
 ```
 
 Once Rust is working, you can install this package via:


### PR DESCRIPTION
This pull request does:

1. Drop the CI for R 4.1
2. Add a CI for R-devel
3. Drop 32bit-related setup from the CI setup and README
4. Use dtolnay/rust-toolchain action instead of unmaintained action-rs/toolchain action

For point 1, I think  we don't care much about the backward-compatibility with that old version. That said, it should be good to test against multiple R versions, so I included point 2, but this is optional.